### PR TITLE
Preloads all audio files to cache on phone

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@react-navigation/stack": "^5.12.8",
     "expo": "~40.0.0",
     "expo-av": "~8.7.0",
+    "expo-file-system": "~9.3.0",
     "expo-status-bar": "~1.0.3",
     "react": "16.13.1",
     "react-dom": "16.13.1",

--- a/src/components/Lesson.js
+++ b/src/components/Lesson.js
@@ -58,10 +58,7 @@ const Lesson = ({ route, navigation, dispatch, completedGrammars }) => {
           <BodyTextExample>A: {jpExample.sentence1}</BodyTextExample>
           <BodyTextExample>B: {jpExample.sentence2}</BodyTextExample>
         </ExampleContainer>
-
-        {jpExample.audio_clip_url && (
-          <SoundPlayButton soundSource={jpExample.audio_clip_url} />
-        )}
+        <SoundPlayButton audioId={jpExample.id} />
       </MediaContainer>
       <ExampleContainer>
         <BodyTextExample>A: {enExample.sentence1}</BodyTextExample>

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -1,15 +1,35 @@
 import * as a from "../rdx/actions";
 
 import React, { useEffect } from "react";
+import { addMultipleAudios } from "./helpers/AudioManagement";
 
 import { connect } from "react-redux";
 import styled from "styled-components/native";
+
+const examplesWithAudio = (resp) => {
+  let examples = [];
+  resp.forEach((dialect) => {
+    dialect.grammars.forEach((grammar) => {
+      grammar.examples.forEach((example) => {
+        if (example.audio_clip_url) {
+          examples.push(example);
+        }
+      });
+    });
+  });
+  return examples;
+};
 
 const Loading = ({ navigation, dispatch }) => {
   useEffect(() => {
     fetch("http://honma-api.herokuapp.com/api/dialects")
       .then((resp) => resp.json())
-      .then((resp) => dispatch(a.loadedDialects(resp)))
+      .then((resp) => {
+        (async () => {
+          await addMultipleAudios(examplesWithAudio(resp));
+        })();
+        dispatch(a.loadedDialects(resp));
+      })
       .then(() => navigation.navigate("ChooseDialect"));
     return () => {};
   }, []);

--- a/src/components/helpers/AudioManagement.js
+++ b/src/components/helpers/AudioManagement.js
@@ -1,0 +1,65 @@
+import * as FileSystem from "expo-file-system";
+
+const audioDir = FileSystem.cacheDirectory + "audio/";
+export const audioFileUri = (exampleId) => audioDir + `audio_${exampleId}.m4a`;
+
+// Checks if audio directory exists. If not, creates it
+async function ensureDirExists() {
+  const dirInfo = await FileSystem.getInfoAsync(audioDir);
+  if (!dirInfo.exists) {
+    console.log("Audio directory doesn't exist, creating...");
+    await FileSystem.makeDirectoryAsync(audioDir, { intermediates: true });
+  }
+}
+
+// Downloads all audios specified as array of IDs
+export async function addMultipleAudios(examples) {
+  try {
+    await ensureDirExists();
+
+    await Promise.all(
+      examples.map(async (example) => {
+        const fileInfo = await FileSystem.getInfoAsync(
+          audioFileUri(example.id)
+        );
+        if (!fileInfo.exists) {
+          console.log("Downloading", example.id, "audio files...");
+          FileSystem.downloadAsync(
+            example.audio_clip_url,
+            audioFileUri(example.id)
+          );
+          console.log("Downloaded", example.id, "audio files...");
+        }
+      })
+    );
+  } catch (e) {
+    console.error("Couldn't download audio files:", e);
+  }
+}
+
+// // Returns URI to our local audio file
+// // If our audio doesn't exist locally, it downloads it
+// export async function getSingleAudio(audioId) {
+//   await ensureDirExists();
+
+//   const fileUri = audioFileUri(audioId);
+//   const fileInfo = await FileSystem.getInfoAsync(fileUri);
+
+//   if (!fileInfo.exists) {
+//     console.log("Audio isn't cached locally. Downloading...");
+//     await FileSystem.downloadAsync(audioUrl(audioId), fileUri);
+//   }
+
+//   return fileUri;
+// }
+
+// Exports shareable URI - it can be shared outside your app
+export async function getAudioContentUri(audioId) {
+  return FileSystem.getContentUriAsync(await getSingleAudio(audioId));
+}
+
+// Deletes whole giphy directory with all its content
+export async function deleteAllAudios() {
+  console.log("Deleting all Audio files...");
+  await FileSystem.deleteAsync(audioDir);
+}

--- a/src/shared/SoundPlayButton.js
+++ b/src/shared/SoundPlayButton.js
@@ -22,14 +22,13 @@ const SoundPlayButton = ({ audioId }) => {
   // Checks to see if audio clip has been downloaded to phone
   // If it has, set the uri to state so we can show the button.
   useEffect(() => {
-    async function checkAudioExists() {
-      const uri = audioFileUri(audioId);
-      const info = await FileSystem.getInfoAsync(uri);
+    const uri = audioFileUri(audioId);
+    FileSystem.getInfoAsync(uri).then((info) => {
       if (info.exists) {
         setAudioUri(uri);
       }
-    }
-    checkAudioExists();
+    });
+    return () => {};
   }, []);
 
   useEffect(() => {

--- a/src/shared/SoundPlayButton.js
+++ b/src/shared/SoundPlayButton.js
@@ -1,22 +1,38 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 import { Audio } from "expo-av";
 import Icon from "react-native-vector-icons/FontAwesome";
 import styled from "styled-components/native";
+import { audioFileUri } from "../components/helpers/AudioManagement";
+import * as FileSystem from "expo-file-system";
 
-const SoundPlayButton = ({ soundSource }) => {
+const SoundPlayButton = ({ audioId }) => {
   const [sound, setSound] = useState();
   const [isPressed, setIsPressed] = useState(false);
+  const [audioUri, setAudioUri] = useState();
 
   async function playSound() {
     btnPressed();
-    const { sound } = await Audio.Sound.createAsync({ uri: soundSource });
+    const { sound } = await Audio.Sound.createAsync({ uri: audioUri });
     setSound(sound);
 
     await sound.playAsync();
   }
 
-  React.useEffect(() => {
+  // Checks to see if audio clip has been downloaded to phone
+  // If it has, set the uri to state so we can show the button.
+  useEffect(() => {
+    async function checkAudioExists() {
+      const uri = audioFileUri(audioId);
+      const info = await FileSystem.getInfoAsync(uri);
+      if (info.exists) {
+        setAudioUri(uri);
+      }
+    }
+    checkAudioExists();
+  }, []);
+
+  useEffect(() => {
     return sound
       ? () => {
           sound.unloadAsync();
@@ -31,15 +47,16 @@ const SoundPlayButton = ({ soundSource }) => {
     }, 200);
   };
 
-  return (
-    <ButtonContainer onPress={() => playSound()}>
-      <Icon
-        name="volume-up"
-        style={{ color: "#fff" }}
-        size={25}
-      />
-    </ButtonContainer>
-  );
+  // Don't show the button if the audio clip hasn't been downloaded
+  if (audioUri) {
+    return (
+      <ButtonContainer onPress={() => playSound()}>
+        <Icon name="volume-up" style={{ color: "#fff" }} size={25} />
+      </ButtonContainer>
+    );
+  }
+
+  return null;
 };
 
 const ButtonContainer = styled.TouchableHighlight.attrs({


### PR DESCRIPTION
This PR changes the way we play audio clips. 

Before every time you pressed the sound button it would make a request to the heroku server to play the m4a file. 

Now all of the audio files will be downloaded on your phone when you first open the app. This will cut down on the amount of mobile data used for the app.

It should also make the playing of the audio quicker because it it is already on the phone. 
