### PR TITLE
Pass selected id to show footer button

### DIFF
--- a/src/components/PatternList.js
+++ b/src/components/PatternList.js
@@ -80,6 +80,7 @@ const PatternList = ({
       btnSubLabel="Go to lesson"
       backComponentName={"ChooseDialect"}
       onPressHandler={() => navigateBtn()}
+      selectedGrammarId={selectedGrammarId}
     >
       <ScrollView>
         <PatternContainer>

--- a/src/shared/ScreenLayout.js
+++ b/src/shared/ScreenLayout.js
@@ -23,6 +23,7 @@ const ScreenLayout = (props) => {
     modal,
     setModal,
     selectedDialectId,
+    selectedGrammarId,
   } = props;
 
   return (
@@ -65,7 +66,7 @@ const ScreenLayout = (props) => {
       </BodyContainer>
 
       <Footer>
-        {btnLabel ? (
+        {btnLabel && selectedDialectId || selectedGrammarId ? (
           <FooterButton
             title={btnLabel}
             subTitle={btnSubLabel}


### PR DESCRIPTION
Followed Misa's suggestion: displaying footer button only when selecting dialect and grammar.

<img width="1048" alt="Screen Shot 2021-02-09 at 9 13 55 AM" src="https://user-images.githubusercontent.com/60206746/107400906-25c29280-6ab7-11eb-9aad-414206c32631.png">

https://www.loom.com/share/10772c440af1401c9181226de0d0adfe
