### PR TITLE
Add carousel

### DIFF
--- a/src/components/PlaceInfoDetaiCarousel.js
+++ b/src/components/PlaceInfoDetaiCarousel.js
@@ -1,0 +1,69 @@
+import React, { useRef, useState, useEffect } from "react";
+import Carousel, { ParallaxImage } from "react-native-snap-carousel";
+import {
+  View,
+  Dimensions,
+  StyleSheet,
+  Platform,
+} from "react-native";
+
+const { width: screenWidth } = Dimensions.get("window");
+
+const PlaceInfoDetailCarousel = ({ imageUrlsEntries }) => {
+  const [entries, setEntries] = useState([]);
+  const carouselRef = useRef(null)
+
+  useEffect(() => {
+    setEntries(imageUrlsEntries);
+  }, []);
+
+  const renderItem = ({ item }, parallaxProps) => {
+    return (
+      <View style={styles.item}>
+        <ParallaxImage
+          source={{ uri: item.illustration }}
+          containerStyle={styles.imageContainer}
+          style={styles.image}
+          parallaxFactor={0.4}
+          {...parallaxProps}
+        />
+      </View>
+    );
+  };
+
+  return (
+    <View style={styles.container}>
+      <Carousel
+        ref={carouselRef}
+        sliderWidth={250}
+        sliderHeight={screenWidth}
+        itemWidth={screenWidth - 60}
+        data={entries}
+        renderItem={renderItem}
+        hasParallaxImages={true}
+      />
+    </View>
+  );
+};
+
+export default PlaceInfoDetailCarousel;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  item: {
+    width: 250,
+    height: 250,
+  },
+  imageContainer: {
+    flex: 1,
+    marginBottom: Platform.select({ ios: 0, android: 1 }), // Prevent a random Android rendering issue
+    backgroundColor: "white",
+    borderRadius: 8,
+  },
+  image: {
+    ...StyleSheet.absoluteFillObject,
+    resizeMode: "cover",
+  },
+});

--- a/src/components/PlaceInfoDetail.js
+++ b/src/components/PlaceInfoDetail.js
@@ -45,7 +45,7 @@ export const PlaceInfoDetail = ({ route, navigation }) => {
                 numberOfLines={expandDescription ? 30 : 10}
                 ellipsizeMode="tail"
               >
-                {selectedDialect.description}{" "}
+                {selectedPlace.description}{" "}
               </ModalBody>
             </ModalWrapper>
           </ModalImageBodyContainer>

--- a/src/components/PlaceInfoDetail.js
+++ b/src/components/PlaceInfoDetail.js
@@ -1,13 +1,24 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { ScrollView, View } from "react-native";
 
 import styled from "styled-components/native";
 import Icon from "react-native-vector-icons/FontAwesome";
+import PlaceInfoDetailCarousel from "./PlaceInfoDetaiCarousel";
 
 export const PlaceInfoDetail = ({ route, navigation }) => {
-  const { selectedDialect, selectedPlace } = route.params;
+  const { selectedPlace } = route.params;
   const [expandDescription, setExpandDescription] = useState(false);
   const imageUrls = selectedPlace.imageUrls;
+  const imageUrlsEntries = [];
+
+  const makeImageUrlsEntries = (urls) => {
+    for (let i = 0; i < urls.length; i++) {
+      imageUrlsEntries.push({ illustration: urls[i] });
+    }
+  };
+  useEffect(() => {
+    makeImageUrlsEntries(imageUrls);
+  }, []);
 
   return (
     <View
@@ -33,11 +44,7 @@ export const PlaceInfoDetail = ({ route, navigation }) => {
             <View></View>
           </ModalHeaderContainer>
           <ModalImageBodyContainer>
-            <ModalBodyImage
-              source={{
-                uri: imageUrls[0],
-              }}
-            />
+            <PlaceInfoDetailCarousel imageUrlsEntries={imageUrlsEntries} />
             <ModalWrapper
               onPress={() => setExpandDescription(!expandDescription)}
             >
@@ -122,14 +129,6 @@ const ModalHeader = styled.Text`
 const ModalImageBodyContainer = styled.View`
   justify-content: center;
   align-items: center;
-`;
-
-const ModalBodyImage = styled.Image`
-  background-color: white;
-  width: 200px;
-  height: 200px;
-  margin: 16px;
-  border-radius: 15px;
 `;
 
 const ModalWrapper = styled.TouchableOpacity``;

--- a/src/components/PlaceInfoList.js
+++ b/src/components/PlaceInfoList.js
@@ -17,6 +17,7 @@ export const GET_PLACE_INFOS = gql`
       imageUrls
       website
       address
+      description
     }
   }
 `;


### PR DESCRIPTION
## Description ✏️ 
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Fixes # (issue) -->
In place info detail page, images can be scrollable when there are multiple images in place info data.
## Type of change ⭐ 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Solution 💡 
Use [react-native-snap-carousel/ pagination](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PAGINATION.md)

https://user-images.githubusercontent.com/60206746/167271390-52bc385a-1612-45b7-adf4-6ef5ed2f1921.mov


<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
<!--
- [ ] Test A
- [ ] Test B
-->
<!-- Add images if available -->
