### PR TITLE
[Card 44] Show alert when no examples

### DIFF
--- a/src/components/PatternList.js
+++ b/src/components/PatternList.js
@@ -29,10 +29,7 @@ const PatternList = ({
 
   const navigateBtn = () => {
     if (selectedGrammarId) {
-      const selectedGrammar = FindById(
-        dialectGrammars,
-        selectedGrammarId
-      );
+      const selectedGrammar = FindById(dialectGrammars, selectedGrammarId);
       navigation.navigate("Lesson", {
         selectedDialect,
         grammar: selectedGrammar,
@@ -44,6 +41,8 @@ const PatternList = ({
 
   const doubleTap = (id) => {
     const selectedGrammar = FindById(dialectGrammars, id);
+    const withExamples = hasExamples(selectedGrammar);
+
     const action = a.selectedGrammar(id);
     if (selectedGrammarId == id || selectedGrammarId == null) {
       dispatch(action);
@@ -52,17 +51,23 @@ const PatternList = ({
         setTimeout(() => {
           counter = 0;
         }, 1200);
-      } else if (counter === 2) {
+      } else if (counter === 2 && withExamples) {
         counter = 0;
         navigation.navigate("Lesson", {
           selectedDialect,
           grammar: selectedGrammar,
         });
+      } else if (counter === 2 && !withExamples) {
+        Alert.alert("More examples and quizzes coming soon!");
       }
     } else {
       dispatch(action);
       counter = 1;
     }
+  };
+
+  const hasExamples = (grammar) => {
+    return grammar.examples.length > 0;
   };
 
   const iconName = (grammar) => {


### PR DESCRIPTION
## Description ✏️ 
After clicking a lesson it shows an error message if a lesson doesn’t have any examples or quizzes.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Fixes # (issue) -->

## Type of change ⭐ 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Solution 💡 
Show “More examples and quizzes coming soon!” in alert box.
![Screenshot 2023-10-05 at 12 20 06 PM](https://github.com/cheemurakami/honma-mobile/assets/60206746/acd217db-90e7-43d8-9299-2383770fe9b3)


<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
<!--
- [ ] Test A
- [ ] Test B
-->
<!-- Add images if available -->
## Notes 📔

## Ticket 🎫 
[Card #44](https://trello.com/c/MAFBtCIh)